### PR TITLE
Bug-Fix for forEach

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -137,7 +137,7 @@
             // iterators
 
             forEach: {value: function(callback, thisArg) {
-                for (i = 0; i < this.length; i++) {
+                for (var i = 0; i < this.length; i++) {
                     callback.call(thisArg, score.dom(this[i]), i, this);
                 }
                 return this;


### PR DESCRIPTION
`forEach` would cause infinite loops when other score.dom functions were
used in the callback.